### PR TITLE
Fix to support passwords containing colon

### DIFF
--- a/auth_mysql.py
+++ b/auth_mysql.py
@@ -88,7 +88,7 @@ def ejabberd_in():
 	(size,) = struct.unpack('>h', input_length)
 	logging.debug('size of data: %i'%size)
 
-	income=sys.stdin.read(size).split(':')
+	income=sys.stdin.read(size).split(':', 4)
 	logging.debug("incoming data: %s"%income)
 
 	return income


### PR DESCRIPTION
The current script will fail if passwords contain ':' as they would be split, this commit should fix that.