### PR TITLE
Fix for passwords containing colons

### DIFF
--- a/auth_mysql.py
+++ b/auth_mysql.py
@@ -88,7 +88,7 @@ def ejabberd_in():
 	(size,) = struct.unpack('>h', input_length)
 	logging.debug('size of data: %i'%size)
 
-	income=sys.stdin.read(size).split(':', 4)
+	income=sys.stdin.read(size).split(':', 3)
 	logging.debug("incoming data: %s"%income)
 
 	return income


### PR DESCRIPTION
The split was added to fix this problem, but the maxsplit parameter is
incorrect.